### PR TITLE
Add markdown_body field to Post schema

### DIFF
--- a/src/api/post/content-types/post/schema.json
+++ b/src/api/post/content-types/post/schema.json
@@ -119,6 +119,9 @@
     },
     "discourse_topic_id": {
       "type": "integer"
+    },
+    "markdown_body": {
+      "type": "text"
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -952,6 +952,7 @@ export interface ApiPostPost extends Schema.CollectionType {
       'api::post.post'
     >;
     discourse_topic_id: Attribute.Integer;
+    markdown_body: Attribute.Text;
     createdAt: Attribute.DateTime;
     updatedAt: Attribute.DateTime;
     publishedAt: Attribute.DateTime;


### PR DESCRIPTION
## Summary
- Added a `markdown_body` field to the Post content-type schema.
- Updated generated types to include `markdown_body` on `api::post.post`.

## Request
https://discord.com/channels/864066763682218004/1482032829566156973/1482035012659446043

## Preview
(Credentials on discord)
https://lpe-cms-app-production.up.railway.app/admin/content-manager/collectionType/api::post.post/1