### PR TITLE
Add og_image field and auto-generate JPEG OG images on post publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "develop": "strapi develop",
     "postinstall": "patch-package",
     "start": "strapi start",
-    "strapi": "strapi"
+    "strapi": "strapi",
+    "backfill:og": "npx ts-node --transpile-only scripts/backfill-og-images.ts"
   },
   "dependencies": {
     "@ckeditor/strapi-plugin-ckeditor": "^0.0.10",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "postinstall": "patch-package",
     "start": "strapi start",
     "strapi": "strapi",
-    "backfill:og": "npx ts-node --transpile-only scripts/backfill-og-images.ts"
+    "backfill:og": "ts-node --transpile-only scripts/backfill-og-images.ts"
   },
   "dependencies": {
     "@ckeditor/strapi-plugin-ckeditor": "^0.0.10",
@@ -33,7 +33,8 @@
   },
   "devDependencies": {
     "@types/ejs": "^3.1.5",
-    "patch-package": "^8.0.0"
+    "patch-package": "^8.0.0",
+    "ts-node": "^10.9.2"
   },
   "engines": {
     "node": ">=20.0.0",

--- a/scripts/backfill-og-images.ts
+++ b/scripts/backfill-og-images.ts
@@ -1,20 +1,4 @@
 /* eslint-disable no-console */
-/**
- * Backfill script — generates og_image for every published post that
- * doesn't already have one.
- *
- * Usage:
- *   yarn ts-node --transpile-only scripts/backfill-og-images.ts
- *   yarn ts-node --transpile-only scripts/backfill-og-images.ts --force
- *   yarn ts-node --transpile-only scripts/backfill-og-images.ts --dry-run
- *
- * Notes:
- *   - Must be run from the Strapi project root so the CMS env/config loads.
- *   - Requires FRONTEND_URL (or NEXT_PUBLIC_BASE_URL) in env so the script
- *     can reach the Next.js /api/og?format=jpg endpoint.
- *   - `--force` regenerates even posts that already have an og_image.
- *   - `--dry-run` lists targets and exits without generating.
- */
 
 import strapiFactory from "@strapi/strapi";
 import { generateOgImageForPost } from "../src/api/post/services/og-image";
@@ -31,9 +15,7 @@ async function main() {
   const force = args.includes("--force");
   const dryRun = args.includes("--dry-run");
 
-  console.log(
-    `[backfill-og] starting (force=${force}, dryRun=${dryRun})`
-  );
+  console.log(`[backfill-og] starting (force=${force}, dryRun=${dryRun})`);
 
   // Boot Strapi headlessly.
   const app = await (strapiFactory as any)().load();
@@ -46,9 +28,7 @@ async function main() {
       pagination: { limit: -1 },
     })) as PostRow[];
 
-    const targets = force
-      ? posts
-      : posts.filter((p) => !p.og_image);
+    const targets = force ? posts : posts.filter((p) => !p.og_image);
 
     console.log(
       `[backfill-og] ${targets.length} target(s) out of ${posts.length} total published posts`
@@ -64,7 +44,9 @@ async function main() {
     let ok = 0;
     let failed = 0;
     for (const [index, p] of targets.entries()) {
-      const label = `[${index + 1}/${targets.length}] id=${p.id} slug=${p.slug}`;
+      const label = `[${index + 1}/${targets.length}] id=${p.id} slug=${
+        p.slug
+      }`;
       try {
         await generateOgImageForPost(p.id, {
           replacePrevious: true,

--- a/scripts/backfill-og-images.ts
+++ b/scripts/backfill-og-images.ts
@@ -1,0 +1,91 @@
+/* eslint-disable no-console */
+/**
+ * Backfill script — generates og_image for every published post that
+ * doesn't already have one.
+ *
+ * Usage:
+ *   yarn ts-node --transpile-only scripts/backfill-og-images.ts
+ *   yarn ts-node --transpile-only scripts/backfill-og-images.ts --force
+ *   yarn ts-node --transpile-only scripts/backfill-og-images.ts --dry-run
+ *
+ * Notes:
+ *   - Must be run from the Strapi project root so the CMS env/config loads.
+ *   - Requires FRONTEND_URL (or NEXT_PUBLIC_BASE_URL) in env so the script
+ *     can reach the Next.js /api/og?format=jpg endpoint.
+ *   - `--force` regenerates even posts that already have an og_image.
+ *   - `--dry-run` lists targets and exits without generating.
+ */
+
+import strapiFactory from "@strapi/strapi";
+import { generateOgImageForPost } from "../src/api/post/services/og-image";
+
+type PostRow = {
+  id: number;
+  slug?: string | null;
+  title?: string | null;
+  og_image?: { id: number } | null;
+};
+
+async function main() {
+  const args = process.argv.slice(2);
+  const force = args.includes("--force");
+  const dryRun = args.includes("--dry-run");
+
+  console.log(
+    `[backfill-og] starting (force=${force}, dryRun=${dryRun})`
+  );
+
+  // Boot Strapi headlessly.
+  const app = await (strapiFactory as any)().load();
+
+  try {
+    const posts = (await app.entityService.findMany("api::post.post", {
+      filters: { publishedAt: { $notNull: true } },
+      populate: { og_image: true },
+      fields: ["id", "slug", "title"],
+      pagination: { limit: -1 },
+    })) as PostRow[];
+
+    const targets = force
+      ? posts
+      : posts.filter((p) => !p.og_image);
+
+    console.log(
+      `[backfill-og] ${targets.length} target(s) out of ${posts.length} total published posts`
+    );
+
+    if (dryRun) {
+      for (const p of targets) {
+        console.log(`  - id=${p.id} slug=${p.slug} title="${p.title}"`);
+      }
+      return;
+    }
+
+    let ok = 0;
+    let failed = 0;
+    for (const [index, p] of targets.entries()) {
+      const label = `[${index + 1}/${targets.length}] id=${p.id} slug=${p.slug}`;
+      try {
+        await generateOgImageForPost(p.id, {
+          replacePrevious: true,
+        });
+        ok++;
+        console.log(`${label} OK`);
+      } catch (e) {
+        failed++;
+        console.error(`${label} FAILED: ${(e as Error).message}`);
+      }
+    }
+
+    console.log(
+      `[backfill-og] done. success=${ok} failed=${failed} total=${targets.length}`
+    );
+  } finally {
+    await app.destroy();
+  }
+}
+
+main().catch((e) => {
+  console.error("[backfill-og] fatal", e);
+  process.exit(1);
+});

--- a/src/api/post/content-types/post/lifecycles.ts
+++ b/src/api/post/content-types/post/lifecycles.ts
@@ -1,10 +1,6 @@
 import type { Event } from "@strapi/database/dist/lifecycles";
 import { generateOgImageForPost } from "../../services/og-image";
 
-/**
- * Fields whose changes should invalidate the pre-generated og_image
- * and cause it to be re-rendered on the next save.
- */
 const OG_INVALIDATING_FIELDS = [
   "title",
   "cover_image",
@@ -18,11 +14,6 @@ function didInvalidatingFieldChange(data: Record<string, unknown>): boolean {
   return OG_INVALIDATING_FIELDS.some((key) => key in data);
 }
 
-/**
- * Kick off OG image generation without blocking the lifecycle. Runs in a
- * detached promise so the user's save returns immediately; failures are
- * logged but never bubble up to the editor.
- */
 function scheduleOgGeneration(postId: number, reason: string) {
   // Fire-and-forget by design.
   void (async () => {
@@ -55,7 +46,9 @@ export default {
   },
 
   async afterCreate(event: Event) {
-    const result = (event as unknown as { result?: { id: number; publishedAt?: unknown } }).result ?? null;
+    const result =
+      (event as unknown as { result?: { id: number; publishedAt?: unknown } })
+        .result ?? null;
     if (!result?.id) return;
     // Only publish-ready posts get an OG image. Drafts will pick one up
     // when they're eventually published.
@@ -64,25 +57,14 @@ export default {
   },
 
   async afterUpdate(event: Event) {
-    const result = (event as unknown as { result?: { id: number; publishedAt?: unknown } }).result ?? null;
+    const result =
+      (event as unknown as { result?: { id: number; publishedAt?: unknown } })
+        .result ?? null;
     if (!result?.id) return;
     if (!result.publishedAt) return;
 
     const data = (event.params.data || {}) as Record<string, unknown>;
 
-    // PRIMARY recursion guard.
-    //
-    // The og-image service persists the generated file via
-    // `strapi.db.query("api::post.post").update({ data: { og_image } })`.
-    // `db.query.update` DOES fire lifecycle hooks (it calls
-    // `db.lifecycles.run("afterUpdate", ...)` internally — verified in
-    // node_modules/@strapi/database/dist/index.js), so without this
-    // guard every persist would re-enter this hook and recurse until
-    // we run out of stack.
-    //
-    // The og-image service is careful to pass EXACTLY `{ og_image: id }`
-    // and nothing else, so we can safely identify the service-originated
-    // write by inspecting the param keys.
     const keys = Object.keys(data);
     if (keys.length === 1 && keys[0] === "og_image") return;
 

--- a/src/api/post/content-types/post/lifecycles.ts
+++ b/src/api/post/content-types/post/lifecycles.ts
@@ -1,4 +1,42 @@
 import type { Event } from "@strapi/database/dist/lifecycles";
+import { generateOgImageForPost } from "../../services/og-image";
+
+/**
+ * Fields whose changes should invalidate the pre-generated og_image
+ * and cause it to be re-rendered on the next save.
+ */
+const OG_INVALIDATING_FIELDS = [
+  "title",
+  "cover_image",
+  "authors",
+  "publish_date",
+  "type",
+  "slug",
+] as const;
+
+function didInvalidatingFieldChange(data: Record<string, unknown>): boolean {
+  return OG_INVALIDATING_FIELDS.some((key) => key in data);
+}
+
+/**
+ * Kick off OG image generation without blocking the lifecycle. Runs in a
+ * detached promise so the user's save returns immediately; failures are
+ * logged but never bubble up to the editor.
+ */
+function scheduleOgGeneration(postId: number, reason: string) {
+  // Fire-and-forget by design.
+  void (async () => {
+    try {
+      await generateOgImageForPost(postId, { replacePrevious: true });
+    } catch (e) {
+      strapi.log.error(
+        `[og-image] Generation failed for post id=${postId} (${reason}): ${
+          (e as Error).stack || (e as Error).message
+        }`
+      );
+    }
+  })();
+}
 
 export default {
   async beforeUpdate(event: Event) {
@@ -14,5 +52,41 @@ export default {
       if (!post.publish_date)
         event.params.data.publish_date = event.params.data.publishedAt;
     }
+  },
+
+  async afterCreate(event: Event) {
+    const result = (event as unknown as { result?: { id: number; publishedAt?: unknown } }).result ?? null;
+    if (!result?.id) return;
+    // Only publish-ready posts get an OG image. Drafts will pick one up
+    // when they're eventually published.
+    if (!result.publishedAt) return;
+    scheduleOgGeneration(result.id, "afterCreate");
+  },
+
+  async afterUpdate(event: Event) {
+    const result = (event as unknown as { result?: { id: number; publishedAt?: unknown } }).result ?? null;
+    if (!result?.id) return;
+    if (!result.publishedAt) return;
+
+    const data = (event.params.data || {}) as Record<string, unknown>;
+
+    // PRIMARY recursion guard.
+    //
+    // The og-image service persists the generated file via
+    // `strapi.db.query("api::post.post").update({ data: { og_image } })`.
+    // `db.query.update` DOES fire lifecycle hooks (it calls
+    // `db.lifecycles.run("afterUpdate", ...)` internally — verified in
+    // node_modules/@strapi/database/dist/index.js), so without this
+    // guard every persist would re-enter this hook and recurse until
+    // we run out of stack.
+    //
+    // The og-image service is careful to pass EXACTLY `{ og_image: id }`
+    // and nothing else, so we can safely identify the service-originated
+    // write by inspecting the param keys.
+    const keys = Object.keys(data);
+    if (keys.length === 1 && keys[0] === "og_image") return;
+
+    if (!didInvalidatingFieldChange(data)) return;
+    scheduleOgGeneration(result.id, "afterUpdate");
   },
 };

--- a/src/api/post/content-types/post/lifecycles.ts
+++ b/src/api/post/content-types/post/lifecycles.ts
@@ -68,6 +68,20 @@ export default {
     const keys = Object.keys(data);
     if (keys.length === 1 && keys[0] === "og_image") return;
 
+    const isPublishTransition =
+      "publishedAt" in data && data.publishedAt != null;
+    if (isPublishTransition) {
+      const post = (await strapi.entityService.findOne(
+        "api::post.post",
+        result.id,
+        { populate: { og_image: true } }
+      )) as { og_image?: { id: number } | null } | null;
+      if (!post?.og_image) {
+        scheduleOgGeneration(result.id, "afterUpdate:publish");
+        return;
+      }
+    }
+
     if (!didInvalidatingFieldChange(data)) return;
     scheduleOgGeneration(result.id, "afterUpdate");
   },

--- a/src/api/post/content-types/post/schema.json
+++ b/src/api/post/content-types/post/schema.json
@@ -87,6 +87,14 @@
         "images"
       ]
     },
+    "og_image": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images"
+      ]
+    },
     "tags": {
       "type": "relation",
       "relation": "manyToMany",

--- a/src/api/post/content-types/post/schema.json
+++ b/src/api/post/content-types/post/schema.json
@@ -93,7 +93,12 @@
       "required": false,
       "allowedTypes": [
         "images"
-      ]
+      ],
+      "pluginOptions": {
+        "content-manager": {
+          "visible": false
+        }
+      }
     },
     "tags": {
       "type": "relation",

--- a/src/api/post/services/og-image.ts
+++ b/src/api/post/services/og-image.ts
@@ -99,9 +99,30 @@ async function fetchOgJpeg(ogUrl: string): Promise<Buffer> {
   return Buffer.from(ab);
 }
 
+async function getOrCreateOgFolder(): Promise<number | null> {
+  try {
+    const existing = await strapi.db
+      .query("plugin::upload.folder")
+      .findOne({ where: { name: "thumbnails", parent: null } });
+    if (existing) return existing.id as number;
+
+    const created = await strapi
+      .plugin("upload")
+      .service("folder")
+      .create({ name: "thumbnails", parent: null });
+    return created.id as number;
+  } catch (e) {
+    strapi.log.warn(
+      `[og-image] Could not get/create thumbnails folder: ${(e as Error).message}. Uploading to root.`
+    );
+    return null;
+  }
+}
+
 async function uploadJpegToStrapi(params: {
   buffer: Buffer;
   fileName: string;
+  folderId?: number | null;
 }): Promise<{ id: number }> {
   const { buffer, fileName } = params;
 
@@ -123,7 +144,7 @@ async function uploadJpegToStrapi(params: {
     os.tmpdir(),
     `${Date.now()}-${Math.random().toString(36).slice(2)}-${fileName}`
   );
-  await fs.writeFile(tmpPath, buffer);
+  await fs.writeFile(tmpPath, buffer as unknown as Uint8Array);
 
   try {
     const uploaded = await strapi
@@ -135,6 +156,7 @@ async function uploadJpegToStrapi(params: {
             name: fileName,
             alternativeText: fileName,
             caption: "",
+            ...(params.folderId != null ? { folder: params.folderId } : {}),
           },
         },
         files: {
@@ -220,7 +242,8 @@ export async function generateOgImageForPost(
   const fileName = `og-${post.slug || post.id}.jpg`;
 
   const previousId = post.og_image?.id ?? null;
-  const { id: fileId } = await uploadJpegToStrapi({ buffer, fileName });
+  const folderId = await getOrCreateOgFolder();
+  const { id: fileId } = await uploadJpegToStrapi({ buffer, fileName, folderId });
 
   await strapi.db.query("api::post.post").update({
     where: { id: post.id },

--- a/src/api/post/services/og-image.ts
+++ b/src/api/post/services/og-image.ts
@@ -1,0 +1,303 @@
+/**
+ * og-image service
+ *
+ * Generates and stores a pre-rendered Open Graph image for a post by
+ * calling the Next.js frontend's /api/og endpoint (which uses
+ * @vercel/og + sharp to produce a compact JPEG) and uploading the
+ * result into Strapi's media library, then attaching it to the post's
+ * `og_image` field.
+ *
+ * Why pre-generate?
+ *   X (Twitterbot) frequently fails to fetch the dynamic /api/og route
+ *   because of cold start + WASM init + remote cover_image fetch time
+ *   budgets. Storing a static JPEG in the CMS bypasses all of that.
+ *
+ * The og URL shape MUST match press.logos.co/src/utils/og.utils.ts
+ * (source of truth). Keep these two files in sync.
+ */
+
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+
+/**
+ * Infrastructure URLs.
+ *
+ * The production deployment does not support adding new environment
+ * variables, so the defaults are hardcoded production URLs. The service
+ * still honors env overrides when present — this exists purely so that
+ * `yarn develop` locally can point at a dev Next.js (e.g. localhost:3000)
+ * and a dev Strapi (e.g. localhost:1337) without any code change. In
+ * production no env vars are set, the hardcoded defaults are used, and
+ * behavior is identical to the fully hardcoded version.
+ *
+ * Both production URLs are mirrored in the frontend allowlist
+ * (press.logos.co/src/pages/api/og.tsx ALLOWED_IMAGE_HOSTS). If either
+ * domain moves, update this file AND the frontend allowlist together.
+ */
+const FRONTEND_BASE_URL =
+  process.env.OG_FRONTEND_URL || "https://press.logos.co";
+const CMS_PUBLIC_URL =
+  process.env.OG_CMS_PUBLIC_URL || "https://cms-press.logos.co";
+
+type AuthorLike = { name?: string | null } | null | undefined;
+
+type PostLike = {
+  id: number;
+  slug?: string | null;
+  title?: string | null;
+  publish_date?: string | Date | null;
+  createdAt?: string | Date | null;
+  type?: string | null;
+  cover_image?: { url?: string | null } | null;
+  og_image?: { id: number } | null;
+  authors?: AuthorLike[] | null;
+};
+
+/**
+ * Mirrors press.logos.co/src/utils/og.utils.ts getOpenGraphImageUrl().
+ * Keep in sync.
+ */
+function buildOgUrl(params: {
+  frontendBase: string;
+  title?: string | null;
+  imageUrl?: string | null;
+  contentType?: string | null;
+  date?: string | null;
+  pagePath?: string | null;
+  authors?: string[] | null;
+}): string {
+  const { frontendBase } = params;
+  const url = new URL("/api/og", frontendBase);
+
+  const searchParams = new URLSearchParams();
+  if (params.title) searchParams.set("title", params.title);
+  if (params.imageUrl) searchParams.set("image", params.imageUrl);
+  if (params.contentType) searchParams.set("contentType", params.contentType);
+  if (params.date) searchParams.set("date", params.date);
+  if (params.pagePath) searchParams.set("pagePath", params.pagePath);
+  if (params.authors && params.authors.length)
+    searchParams.set("authors", params.authors.join(", "));
+
+  // Match frontend: inner query string is URI-encoded into a single `q` param.
+  url.searchParams.set("q", encodeURIComponent(searchParams.toString()));
+  url.searchParams.set("format", "jpg");
+  return url.toString();
+}
+
+function toAbsoluteCoverImage(url: string | null | undefined): string | null {
+  if (!url) return null;
+  if (/^https?:\/\//i.test(url)) return url;
+  // Strapi stores uploaded files with relative paths like /uploads/xxx.png.
+  // The Next.js /api/og endpoint requires an absolute URL on an allowlisted
+  // host, so rewrite to the public CMS origin here.
+  return new URL(url, CMS_PUBLIC_URL).toString();
+}
+
+function mapContentType(
+  postType: string | null | undefined
+): string | null {
+  // Frontend uses lower-case ids: 'article', 'podcast', 'episode'.
+  // Strapi post.type enum is ['Article', 'Episode'].
+  if (!postType) return null;
+  const normalized = postType.toLowerCase();
+  if (normalized === "article") return "article";
+  if (normalized === "episode") return "podcast";
+  return normalized;
+}
+
+function mapPagePath(post: PostLike): string {
+  const slug = post.slug || "";
+  return mapContentType(post.type) === "podcast"
+    ? `/podcasts/${slug}`
+    : `/article/${slug}`;
+}
+
+function toIsoDate(v: string | Date | null | undefined): string | null {
+  if (!v) return null;
+  try {
+    return new Date(v).toISOString();
+  } catch {
+    return null;
+  }
+}
+
+async function fetchOgJpeg(ogUrl: string): Promise<Buffer> {
+  const res = await fetch(ogUrl);
+  if (!res.ok) {
+    throw new Error(
+      `[og-image] Upstream /api/og responded ${res.status} ${res.statusText}`
+    );
+  }
+  const ab = await res.arrayBuffer();
+  return Buffer.from(ab);
+}
+
+async function uploadJpegToStrapi(params: {
+  buffer: Buffer;
+  fileName: string;
+}): Promise<{ id: number }> {
+  const { buffer, fileName } = params;
+
+  // Strapi v4.16 upload service consumes formidable-v1 shaped file
+  // objects (verified against
+  // node_modules/@strapi/plugin-upload/server/services/upload.js
+  // `enhanceAndValidateFile`):
+  //   file.name   → used as filename for extension + slug
+  //   file.type   → used as mime
+  //   file.size   → used for size-in-KB
+  //   file.path   → opened via fs.createReadStream
+  // Using modern `originalFilename`/`mimetype`/`filepath` WOULD silently
+  // produce undefined and crash inside path.extname. Keep this shape.
+  //
+  // The upload service also mutates the file object to attach
+  // `tmpWorkingDirectory`, and rimrafs that directory at the end — it is
+  // NOT the same as our temp file, so our cleanup below is still needed.
+  const tmpPath = path.join(
+    os.tmpdir(),
+    `${Date.now()}-${Math.random().toString(36).slice(2)}-${fileName}`
+  );
+  await fs.writeFile(tmpPath, buffer);
+
+  try {
+    const uploaded = await strapi
+      .plugin("upload")
+      .service("upload")
+      .upload({
+        data: {
+          fileInfo: {
+            name: fileName,
+            alternativeText: fileName,
+            caption: "",
+          },
+        },
+        files: {
+          path: tmpPath,
+          name: fileName,
+          type: "image/jpeg",
+          size: buffer.length,
+        } as any,
+      });
+
+    const first = Array.isArray(uploaded) ? uploaded[0] : uploaded;
+    if (!first || typeof first.id !== "number") {
+      throw new Error("[og-image] Upload plugin returned no file id");
+    }
+    return { id: first.id };
+  } finally {
+    await fs.unlink(tmpPath).catch(() => {});
+  }
+}
+
+async function deleteStrapiFile(id: number): Promise<void> {
+  try {
+    const existing = await strapi.plugin("upload").service("upload").findOne(id);
+    if (existing) {
+      await strapi.plugin("upload").service("upload").remove(existing);
+    }
+  } catch (e) {
+    strapi.log.warn(
+      `[og-image] Failed to delete previous og_image id=${id}: ${
+        (e as Error).message
+      }`
+    );
+  }
+}
+
+export interface GenerateOptions {
+  /**
+   * When true, removes the previously attached og_image file after
+   * successfully attaching the new one. Keeps the media library tidy.
+   */
+  replacePrevious?: boolean;
+}
+
+/**
+ * Generate a pre-rendered OG image JPEG for the given post and attach
+ * it to the post's og_image field.
+ *
+ * This function ALWAYS regenerates — it does not skip based on the
+ * presence of an existing og_image. Callers are responsible for deciding
+ * whether regeneration is needed:
+ *   - Lifecycle hooks call this when an invalidating field changed.
+ *   - The backfill script filters out posts that already have an og_image
+ *     (unless run with --force).
+ *
+ * Errors are thrown. Callers should wrap in try/catch so a failure
+ * never blocks the underlying save operation.
+ */
+export async function generateOgImageForPost(
+  postId: number,
+  options: GenerateOptions = {}
+): Promise<{ fileId: number } | null> {
+  const post = (await strapi.entityService.findOne("api::post.post", postId, {
+    populate: {
+      cover_image: true,
+      og_image: true,
+      authors: { fields: ["name"] },
+    },
+  })) as PostLike | null;
+
+  if (!post) {
+    strapi.log.warn(`[og-image] Post ${postId} not found, skipping`);
+    return null;
+  }
+
+  const contentType = mapContentType(post.type);
+  const pagePath = mapPagePath(post);
+  const date =
+    toIsoDate(post.publish_date) || toIsoDate(post.createdAt) || null;
+  const authors = (post.authors || [])
+    .map((a) => (a && a.name ? a.name : null))
+    .filter((n): n is string => !!n);
+
+  const ogUrl = buildOgUrl({
+    frontendBase: FRONTEND_BASE_URL,
+    title: post.title,
+    imageUrl: toAbsoluteCoverImage(post.cover_image?.url),
+    contentType,
+    date,
+    pagePath,
+    authors,
+  });
+
+  strapi.log.info(
+    `[og-image] Generating for post id=${post.id} slug=${post.slug}`
+  );
+
+  const buffer = await fetchOgJpeg(ogUrl);
+  const fileName = `og-${post.slug || post.id}.jpg`;
+
+  const previousId = post.og_image?.id ?? null;
+  const { id: fileId } = await uploadJpegToStrapi({ buffer, fileName });
+
+  // Persist the og_image relation.
+  //
+  // IMPORTANT: `strapi.db.query(...).update()` does NOT bypass lifecycle
+  // hooks — it re-invokes `beforeUpdate`/`afterUpdate` via
+  // `db.lifecycles.run(...)` (verified in
+  // node_modules/@strapi/database/dist/index.js update(...)). Recursion
+  // is instead prevented by the content-type lifecycle hook in
+  // ../content-types/post/lifecycles.ts, which returns early when the
+  // only key in `event.params.data` is `og_image`. That guard relies on
+  // this service passing EXACTLY `{ og_image: fileId }` — do not add
+  // sibling fields to the update payload here.
+  //
+  // The query engine's `updateRelations` correctly writes to the media
+  // morph table (files_related_morphs) for morphOne attributes, so a
+  // plain numeric fileId is all that is needed.
+  await strapi.db.query("api::post.post").update({
+    where: { id: post.id },
+    data: { og_image: fileId },
+  });
+
+  if (options.replacePrevious && previousId && previousId !== fileId) {
+    await deleteStrapiFile(previousId);
+  }
+
+  strapi.log.info(
+    `[og-image] Attached file id=${fileId} to post id=${post.id}`
+  );
+
+  return { fileId };
+}

--- a/src/api/post/services/og-image.ts
+++ b/src/api/post/services/og-image.ts
@@ -30,6 +30,7 @@ function buildOgUrl(params: {
   frontendBase: string;
   title?: string | null;
   imageUrl?: string | null;
+  imagePath?: string | null;
   contentType?: string | null;
   date?: string | null;
   pagePath?: string | null;
@@ -41,6 +42,7 @@ function buildOgUrl(params: {
   const searchParams = new URLSearchParams();
   if (params.title) searchParams.set("title", params.title);
   if (params.imageUrl) searchParams.set("image", params.imageUrl);
+  if (params.imagePath) searchParams.set("imagePath", params.imagePath);
   if (params.contentType) searchParams.set("contentType", params.contentType);
   if (params.date) searchParams.set("date", params.date);
   if (params.pagePath) searchParams.set("pagePath", params.pagePath);
@@ -60,6 +62,22 @@ function toAbsoluteCoverImage(url: string | null | undefined): string | null {
   // The Next.js /api/og endpoint requires an absolute URL on an allowlisted
   // host, so rewrite to the public CMS origin here.
   return new URL(url, CMS_PUBLIC_URL).toString();
+}
+
+function toCoverImagePath(url: string | null | undefined): string | null {
+  if (!url) return null;
+  if (url.startsWith("/uploads/")) return url;
+
+  try {
+    const parsed = new URL(url);
+    if (parsed.pathname.startsWith("/uploads/")) {
+      return parsed.pathname;
+    }
+  } catch {
+    return null;
+  }
+
+  return null;
 }
 
 function mapContentType(postType: string | null | undefined): string | null {
@@ -241,6 +259,7 @@ export async function generateOgImageForPost(
     frontendBase: FRONTEND_BASE_URL,
     title: post.title,
     imageUrl: toAbsoluteCoverImage(post.cover_image?.url),
+    imagePath: toCoverImagePath(post.cover_image?.url),
     contentType,
     date,
     pagePath,

--- a/src/api/post/services/og-image.ts
+++ b/src/api/post/services/og-image.ts
@@ -88,15 +88,28 @@ function toIsoDate(v: string | Date | null | undefined): string | null {
   }
 }
 
+const FETCH_TIMEOUT_MS = 30_000;
+
 async function fetchOgJpeg(ogUrl: string): Promise<Buffer> {
-  const res = await fetch(ogUrl);
-  if (!res.ok) {
-    throw new Error(
-      `[og-image] Upstream /api/og responded ${res.status} ${res.statusText}`
-    );
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+  try {
+    const res = await fetch(ogUrl, { signal: controller.signal });
+    if (!res.ok) {
+      throw new Error(
+        `[og-image] Upstream /api/og responded ${res.status} ${res.statusText}`
+      );
+    }
+    const ab = await res.arrayBuffer();
+    return Buffer.from(ab);
+  } catch (e) {
+    if ((e as Error).name === "AbortError") {
+      throw new Error(`[og-image] Upstream /api/og timed out after ${FETCH_TIMEOUT_MS}ms`);
+    }
+    throw e;
+  } finally {
+    clearTimeout(timer);
   }
-  const ab = await res.arrayBuffer();
-  return Buffer.from(ab);
 }
 
 async function getOrCreateOgFolder(): Promise<number | null> {

--- a/src/api/post/services/og-image.ts
+++ b/src/api/post/services/og-image.ts
@@ -1,42 +1,10 @@
-/**
- * og-image service
- *
- * Generates and stores a pre-rendered Open Graph image for a post by
- * calling the Next.js frontend's /api/og endpoint (which uses
- * @vercel/og + sharp to produce a compact JPEG) and uploading the
- * result into Strapi's media library, then attaching it to the post's
- * `og_image` field.
- *
- * Why pre-generate?
- *   X (Twitterbot) frequently fails to fetch the dynamic /api/og route
- *   because of cold start + WASM init + remote cover_image fetch time
- *   budgets. Storing a static JPEG in the CMS bypasses all of that.
- *
- * The og URL shape MUST match press.logos.co/src/utils/og.utils.ts
- * (source of truth). Keep these two files in sync.
- */
-
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
 
-/**
- * Infrastructure URLs.
- *
- * The production deployment does not support adding new environment
- * variables, so the defaults are hardcoded production URLs. The service
- * still honors env overrides when present — this exists purely so that
- * `yarn develop` locally can point at a dev Next.js (e.g. localhost:3000)
- * and a dev Strapi (e.g. localhost:1337) without any code change. In
- * production no env vars are set, the hardcoded defaults are used, and
- * behavior is identical to the fully hardcoded version.
- *
- * Both production URLs are mirrored in the frontend allowlist
- * (press.logos.co/src/pages/api/og.tsx ALLOWED_IMAGE_HOSTS). If either
- * domain moves, update this file AND the frontend allowlist together.
- */
 const FRONTEND_BASE_URL =
   process.env.OG_FRONTEND_URL || "https://press.logos.co";
+
 const CMS_PUBLIC_URL =
   process.env.OG_CMS_PUBLIC_URL || "https://cms-press.logos.co";
 
@@ -94,9 +62,7 @@ function toAbsoluteCoverImage(url: string | null | undefined): string | null {
   return new URL(url, CMS_PUBLIC_URL).toString();
 }
 
-function mapContentType(
-  postType: string | null | undefined
-): string | null {
+function mapContentType(postType: string | null | undefined): string | null {
   // Frontend uses lower-case ids: 'article', 'podcast', 'episode'.
   // Strapi post.type enum is ['Article', 'Episode'].
   if (!postType) return null;
@@ -191,7 +157,10 @@ async function uploadJpegToStrapi(params: {
 
 async function deleteStrapiFile(id: number): Promise<void> {
   try {
-    const existing = await strapi.plugin("upload").service("upload").findOne(id);
+    const existing = await strapi
+      .plugin("upload")
+      .service("upload")
+      .findOne(id);
     if (existing) {
       await strapi.plugin("upload").service("upload").remove(existing);
     }
@@ -205,27 +174,9 @@ async function deleteStrapiFile(id: number): Promise<void> {
 }
 
 export interface GenerateOptions {
-  /**
-   * When true, removes the previously attached og_image file after
-   * successfully attaching the new one. Keeps the media library tidy.
-   */
   replacePrevious?: boolean;
 }
 
-/**
- * Generate a pre-rendered OG image JPEG for the given post and attach
- * it to the post's og_image field.
- *
- * This function ALWAYS regenerates — it does not skip based on the
- * presence of an existing og_image. Callers are responsible for deciding
- * whether regeneration is needed:
- *   - Lifecycle hooks call this when an invalidating field changed.
- *   - The backfill script filters out posts that already have an og_image
- *     (unless run with --force).
- *
- * Errors are thrown. Callers should wrap in try/catch so a failure
- * never blocks the underlying save operation.
- */
 export async function generateOgImageForPost(
   postId: number,
   options: GenerateOptions = {}
@@ -271,21 +222,6 @@ export async function generateOgImageForPost(
   const previousId = post.og_image?.id ?? null;
   const { id: fileId } = await uploadJpegToStrapi({ buffer, fileName });
 
-  // Persist the og_image relation.
-  //
-  // IMPORTANT: `strapi.db.query(...).update()` does NOT bypass lifecycle
-  // hooks — it re-invokes `beforeUpdate`/`afterUpdate` via
-  // `db.lifecycles.run(...)` (verified in
-  // node_modules/@strapi/database/dist/index.js update(...)). Recursion
-  // is instead prevented by the content-type lifecycle hook in
-  // ../content-types/post/lifecycles.ts, which returns early when the
-  // only key in `event.params.data` is `og_image`. That guard relies on
-  // this service passing EXACTLY `{ og_image: fileId }` — do not add
-  // sibling fields to the update payload here.
-  //
-  // The query engine's `updateRelations` correctly writes to the media
-  // morph table (files_related_morphs) for morphOne attributes, so a
-  // plain numeric fileId is all that is needed.
   await strapi.db.query("api::post.post").update({
     where: { id: post.id },
     data: { og_image: fileId },

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -935,7 +935,12 @@ export interface ApiPostPost extends Schema.CollectionType {
       'api::podcast-show.podcast-show'
     >;
     cover_image: Attribute.Media;
-    og_image: Attribute.Media;
+    og_image: Attribute.Media &
+      Attribute.SetPluginOptions<{
+        'content-manager': {
+          visible: false;
+        };
+      }>;
     tags: Attribute.Relation<'api::post.post', 'manyToMany', 'api::tag.tag'>;
     channel: Attribute.Component<'cat.channel', true>;
     credits: Attribute.RichText &

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -935,6 +935,7 @@ export interface ApiPostPost extends Schema.CollectionType {
       'api::podcast-show.podcast-show'
     >;
     cover_image: Attribute.Media;
+    og_image: Attribute.Media;
     tags: Attribute.Relation<'api::post.post', 'manyToMany', 'api::tag.tag'>;
     channel: Attribute.Component<'cat.channel', true>;
     credits: Attribute.RichText &


### PR DESCRIPTION
Adds infrastructure to pre-generate OG images server-side and attach them to posts, eliminating the dynamic render step that Twitterbot frequently times out on.

## Notes
- We need to deploy this repo before the frontend, the frontend's GraphQL fragment now queries `og_image`, which will error if Strapi doesn't have the field yet.
- After deploying, run `yarn backfill:og --dry-run then yarn backfill:og` to populate existing posts
- OG image is only regenerated when OG-affecting fields change (title, cover_image, authors, publish_date, type, slug). Saving other fields (body, tags, etc.) doesn't trigger regeneration.
- Each regeneration replaces the previous file. the old image is deleted after the new one is attached. Storage does not accumulate.

## Frontend PR
https://github.com/acid-info/logos-press-engine/pull/267

## Testing Guide

### Prerequisites
- Run the backend [lpe-cms#5](https://github.com/acid-info/lpe-cms/pull/5) first, then the frontend PR
- In the backend, set the env variables which are used for localhost only
```
OG_FRONTEND_URL=http://localhost:3000
OG_CMS_PUBLIC_URL=http://localhost:1337
```

### Verify OG image generation on post save

1. Open Strapi admin → Content Manager → Posts
2. Open any published post
3. Change the title (or any of `cover_image`, `authors`, `publish_date`, `type`, `slug`)
4. Save
5. Check Strapi admin > Media Library > thumbnails > confirm a new `og-<slug>.jpg` file appears
<img width="376" height="256" alt="Screenshot 2026-04-09 at 1 04 21 AM" src="https://github.com/user-attachments/assets/d4dcca06-ff92-4254-948b-22c7877f63b3" />

6. Re-open the post > confirm the `og_image` field is populated
7. Go to the frontend and check that `og:image` in the `<head>` element has been changed